### PR TITLE
Probably a good idea to turn off the embedded database

### DIFF
--- a/SupportFiles/gitlab_config.sh
+++ b/SupportFiles/gitlab_config.sh
@@ -73,6 +73,7 @@ external_url 'https://${GITLAB_EXTERNURL}'
 nginx['listen_addresses'] = ["0.0.0.0", "[::]"]
 nginx['listen_port'] = 80
 nginx['listen_https'] = false
+postgresql['enable'] = false
 gitlab_rails['db_adapter'] = "postgresql"
 gitlab_rails['db_encoding'] = "unicode"
 gitlab_rails['db_database'] = "${GITLAB_DATABASE}"


### PR DESCRIPTION
Enabled use of PGSQL via RDS but forgot to configure the embedded PGSQL to not start. This fix should reduce resource utilization and lower potential attack-surface.